### PR TITLE
HLApp: Fix ethernet setup instructions

### DIFF
--- a/Firmware/HLApp/Cactusphere_100/main.c
+++ b/Firmware/HLApp/Cactusphere_100/main.c
@@ -397,10 +397,6 @@ int main(int argc, char *argv[])
         Log_Debug("Error setting hardware address (eth0) %d\n", errno);
     }
 
-    err = Networking_SetInterfaceState("eth0", true);
-    if (err < 0) {
-        Log_Debug("Error setting interface state (eth0) %d\n", errno);
-    }
     ParseCommandLineArguments(argc, argv);
 
     exitCode = ValidateUserConfiguration();


### PR DESCRIPTION
Ethernet enabled by default (21.04～) :
https://docs.microsoft.com/en-us/azure-sphere/product-overview/whats-new#ethernet-enabled-by-default